### PR TITLE
Don't count the email address as an address

### DIFF
--- a/parseMail.go
+++ b/parseMail.go
@@ -140,7 +140,9 @@ func processHeaders(
 					addresses,
 				)
 				if aD, ok := retval[normaddr]; ok {
-					aD.Names = append(aD.Names, name)
+					if normaddr != strings.ToLower(name) {
+						aD.Names = append(aD.Names, name)
+					}
 					if aD.Class < class {
 						aD.Class = class
 					}
@@ -153,7 +155,9 @@ func processHeaders(
 					aD := AddressData{}
 					aD.Address = normaddr
 					aD.Class = class
-					aD.Names = append(aD.Names, name)
+					if normaddr != strings.ToLower(name) {
+						aD.Names = append(aD.Names, name)
+					}
 					aD.ClassDate = [3]int64{0, 0, 0}
 					aD.ClassDate[class] = time.Unix()
 					aD.ClassCount = [3]int{0, 0, 0}


### PR DESCRIPTION
I found it to be a non-trivial scenario where the header name is equal to the email address though sometimes it's not capitalized. With this change it's skipped when parsing and although it adds a string comparison for every mail parsed, it may alleviate the function related to choosing the name since there are some less to parse. I found the resulting cache to be slightly better to my liking.