### PR TITLE
Feature: add addressbook lookup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Why? No need to manually edit an address book, yet the cached ranking is
 available extremely fast.
 
 ### Features:
+
 - scans all your emails
 - ranks based on both recency and frequency of addresses
 - collects from To, Cc, Bcc and From fields
@@ -16,13 +17,15 @@ available extremely fast.
 - uses the most frequent non-empty display name for each email
 - filters common "no reply" addresses, additional filters can be added via regexes
 - normalizes emails to lower case
-- "blazingly fast"<sup>*</sup>: crunch time for 270k emails is 7s on my machine, grepping from the output is instantaneous
+- ability to add additional email addresses from a command
+- "blazingly fast"<sup>\*</sup>: crunch time for 270k emails is 7s on my machine, grepping from the output is instantaneous
 
-<sup>*</sup>: compared to original python implementation for crunching (see Behind the scenes below) and compared to using notmuch query for address completion
+<sup>\*</sup>: compared to original python implementation for crunching (see Behind the scenes below) and compared to using notmuch query for address completion
 
 # Installation
 
 The easiest way to install is running:
+
 ```
 go install github.com/ferdinandyb/maildir-rank-addr@latest
 ```
@@ -41,6 +44,8 @@ or systemd timer).
 Supported flags:
 
 ```
+      --addr-book-cmd string   optional command to query addresses from your addressbook
+      --addr-book-add-unmatched if cmd is stated, determine wether to add unmatched addresses at the end of the file (true or false)
       --addresses strings   comma separated list of your email addresses (regex possible)
       --config string       path to config file
       --filters strings     comma separated list of regexes to filter
@@ -67,6 +72,7 @@ classification based on your explicit sends will not be possible!
 
 Uses go's `text/template` to configure output for each address (one line per address).
 Available keys:
+
 ```
 	Address
 	Name
@@ -101,6 +107,18 @@ before the @) matches any of these strings:
 	"nincsvalasz",
 ```
 
+**addr-book-cmd**
+
+Optional command to fetch email addresses and names, the output it returns must have
+an email address first, followed by a tab space and and the desired name, the name
+must end in a tab space or a newline for the command to work, this can be
+useful for integrating with command line addressbooks such as abook or khard
+
+```
+abook --mutt-query "s"
+khard email -p --remove-first-line
+```
+
 **config**
 
 Path to a config file to be loaded instead of the defaults (see below).
@@ -124,12 +142,12 @@ outputpath = "~/.mail/addressbook"
 template = "{{.Address}}\t{{.Name}}"
 ```
 
-
 ## Integration
 
 #### aerc
 
 Put something like this in your aerc config (using your favourite grep):
+
 ```
 address-book-cmd="ugrep -jP -m 100 --color=never %s /home/[myuser]/.cache/maildir-rank-addr/addressbook.tsv"
 ```
@@ -144,7 +162,6 @@ code the path without shell expansion.
 ## Ranking
 
 Ranking is actually done by first classifying and then ranking within class.
-
 
 ### Classifying addresses
 
@@ -211,7 +228,6 @@ Please see [contribution guidelines](https://github.com/ferdinandyb/maildir-rank
 - [maildir2addr](https://github.com/BourgeoisBear/maildir2addr): somewhat similar address book generator
 - [notmuch-addrlookup-c](https://github.com/aperezdc/notmuch-addrlookup-c): address lookup from notmuch
 - [addr-book-combine](https://jasoncarloscox.com/creations/addr-book-combine/): for combining generated addressbooks with hand currated ones, like [khard](https://github.com/lucc/khard)
-
 
 # Acknowledgments
 

--- a/data.go
+++ b/data.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os/exec"
 	"regexp"
 	"text/template"
 )
@@ -18,9 +19,11 @@ type AddressData struct {
 }
 
 type Config struct {
-	maildir       string
-	outputpath    string
-	addresses     []*regexp.Regexp
-	template      *template.Template
-	customFilters []*regexp.Regexp
+	maildir                  string
+	outputpath               string
+	addresses                []*regexp.Regexp
+	template                 *template.Template
+	customFilters            []*regexp.Regexp
+	addressbookLookupCommand *exec.Cmd
+	addressbookAddUnmatched  bool
 }

--- a/maildir-rank-addr.go
+++ b/maildir-rank-addr.go
@@ -1,10 +1,9 @@
 package main
 
-import ()
-
 func main() {
 	config := loadConfig()
-	data := walkMaildir(config.maildir, config.addresses, config.customFilters)
+	addressbook := parseAddressbook(config.addressbookLookupCommand)
+	data := walkMaildir(config.maildir, config.addresses, config.customFilters, addressbook)
 	classeddata := calculateRanks(data)
-	saveData(classeddata, config.outputpath, config.template)
+	saveData(classeddata, config.outputpath, config.template, addressbook, config.addressbookAddUnmatched)
 }

--- a/output.go
+++ b/output.go
@@ -13,10 +13,11 @@ func saveData(
 	classedData map[int]map[string]AddressData,
 	path string,
 	tmpl *template.Template,
+	addressbook map[string]string,
+	addUnmatched bool,
 ) {
 	os.MkdirAll(filepath.Dir(path), os.ModePerm)
 	f, err := os.Create(path)
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -44,6 +45,15 @@ func saveData(
 		for _, kv := range s {
 			count++
 			tmpl.Execute(f, kv.Value)
+		}
+	}
+	if addUnmatched {
+		for ak, av := range addressbook {
+			aD := AddressData{}
+			aD.Address = ak
+			aD.Name = av
+			count++
+			tmpl.Execute(f, aD)
 		}
 	}
 	fmt.Println(count, " addresses written to ", path)

--- a/parseAddressbook.go
+++ b/parseAddressbook.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+func parseAddressbook(
+	cmd *exec.Cmd,
+) map[string]string {
+	if cmd == nil {
+		return nil
+	}
+	addressbook := make(map[string]string)
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	scanner := bufio.NewScanner(out)
+	for scanner.Scan() {
+		slice := strings.Split(scanner.Text(), "\t")
+		if len(slice) < 2 {
+			fmt.Println("Couldn't parse ", scanner.Text())
+		} else {
+			addressbook[strings.ToLower(slice[0])] = slice[1]
+		}
+	}
+	if err := cmd.Wait(); err != nil {
+		log.Fatal(err)
+	}
+	return addressbook
+}

--- a/ranking.go
+++ b/ranking.go
@@ -32,6 +32,9 @@ func getMostFrequent(names []string) string {
 }
 
 func normalizeAddressNames(aD AddressData) AddressData {
+	if aD.Name != "" {
+		return aD
+	}
 	aD.Name = getMostFrequent(aD.Names)
 	return aD
 }


### PR DESCRIPTION
Added address book lookup command option, if set either via flag or as an entry in the config file, this is how the execution will change:
- It will read the command's stdout and extract from there a map of names indexed by email address
- During mail parsing, when creating a new AddressData struct, it will check the address in said map
- If it finds a match, it will:
    - Set the AddressData.Name value
    - Skip not just adding the name to the list, but parsing it from the email alltogether
    - Delete the key from the addressbook match
- When returning an existing AddressData, instead of checking the addressbook, it checks the AddressData.Name variable.
- The AddressData.Name variable is once again checked before executing the function that checks for name in addresses to skip it if already set
- After outputting the classed data, it iterates over the remaining addressbook entries in the map (those that weren't deleted)
- It instantiates AddressData structs with its values and prints them according to the format
