### PR TITLE
Allow to specify multiple maildirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Supported flags:
       --addresses strings   comma separated list of your email addresses (regex possible)
       --config string       path to config file
       --filters strings     comma separated list of regexes to filter
-      --maildir string      path to maildir folder
+      --maildir strings     comma separated list of paths to maildir folders
       --outputpath string   path to output file
       --template string     output template
 ```
 
 **maildir**
 
-The path to the folder that will be scanned. No default is set for this.
+The paths to the folders that will be scanned. No default is set for this.
 
 **outputpath**
 

--- a/config.go
+++ b/config.go
@@ -15,7 +15,7 @@ import (
 
 func loadConfig() Config {
 	pflag.String("config", "", "path to config file")
-	pflag.String("maildir", "", "path to maildir folder")
+	pflag.StringSlice("maildir", []string{}, "comma separated list of paths to maildir folders")
 	pflag.String("outputpath", "", "path to output file")
 	pflag.String("template", "", "output template")
 	pflag.String("addr-book-cmd", "", "optional command to query addresses from your addressbook")
@@ -52,11 +52,15 @@ func loadConfig() Config {
 			panic(fmt.Errorf("fatal error config file: %w", err))
 		}
 	}
-	if viper.Get("maildir") == "" {
+	if len(viper.GetStringSlice("maildir")) == 0 {
 		pflag.PrintDefaults()
 		os.Exit(1)
 	}
-	maildir, _ := homedir.Expand(viper.GetString("maildir"))
+	maildirInput := viper.GetStringSlice("maildir")
+	maildirs := make([]string, len(maildirInput))
+	for i, maildir := range maildirInput {
+		maildirs[i], _ = homedir.Expand(maildir)
+	}
 	outputpath, _ := homedir.Expand(viper.GetString("outputpath"))
 	filterInput := viper.GetStringSlice("filters")
 	customFilters := make([]*regexp.Regexp, len(filterInput))
@@ -86,7 +90,7 @@ func loadConfig() Config {
 		panic(fmt.Errorf("bad template"))
 	}
 	config := Config{
-		maildir:                  maildir,
+		maildirs:                 maildirs,
 		outputpath:               outputpath,
 		addresses:                addresses,
 		template:                 tmpl,

--- a/data.go
+++ b/data.go
@@ -20,7 +20,7 @@ type AddressData struct {
 }
 
 type Config struct {
-	maildir                  string
+	maildirs                 []string
 	outputpath               string
 	addresses                []*regexp.Regexp
 	template                 *template.Template

--- a/maildir-rank-addr.go
+++ b/maildir-rank-addr.go
@@ -3,7 +3,7 @@ package main
 func main() {
 	config := loadConfig()
 	addressbook := parseAddressbook(config.addressbookLookupCommand)
-	data := walkMaildir(config.maildir, config.addresses, config.customFilters, addressbook)
+	data := walkMaildirs(config.maildirs, config.addresses, config.customFilters, addressbook)
 	classeddata := calculateRanks(data)
 	saveData(classeddata, config.outputpath, config.template, addressbook, config.addressbookAddUnmatched)
 }


### PR DESCRIPTION
This allows to run maildir-rank-addr on multiple maildirs. The addresses of the individual maildirs will be merged together.

I didn't rename the `--maildir` option to `--maildirs` to retain backwards compatibility.